### PR TITLE
Fix xUnit2006 warning

### DIFF
--- a/Tests/SmartGlass/TestBroadcastJson.cs
+++ b/Tests/SmartGlass/TestBroadcastJson.cs
@@ -56,7 +56,7 @@ namespace Tests.SmartGlass
 
             Assert.Equal<BroadcastMessageType>(BroadcastMessageType.GamestreamState, msg.Type);
             Assert.Equal<GamestreamStateMessageType>(GamestreamStateMessageType.Initializing, msg.State);
-            Assert.Equal<string>("14608f3c-1c4a-4f32-9da6-179ce1001e4a", msg.SessionId.ToString());
+            Assert.Equal("14608f3c-1c4a-4f32-9da6-179ce1001e4a", msg.SessionId.ToString());
             Assert.Equal<int>(53394, msg.TcpPort);
             Assert.Equal<int>(49665, msg.UdpPort);
         }
@@ -69,7 +69,7 @@ namespace Tests.SmartGlass
 
             Assert.Equal<BroadcastMessageType>(BroadcastMessageType.GamestreamState, msg.Type);
             Assert.Equal<GamestreamStateMessageType>(GamestreamStateMessageType.Started, msg.State);
-            Assert.Equal<string>("14608f3c-1c4a-4f32-9da6-179ce1001e4a", msg.SessionId.ToString());
+            Assert.Equal("14608f3c-1c4a-4f32-9da6-179ce1001e4a", msg.SessionId.ToString());
             Assert.False(msg.IsWirelessConnection);
             Assert.Equal<int>(0, msg.WirelessChannel);
             Assert.Equal<int>(1000000000, msg.TransmitLinkSpeed);
@@ -84,7 +84,7 @@ namespace Tests.SmartGlass
 
             Assert.Equal<BroadcastMessageType>(BroadcastMessageType.GamestreamState, msg.Type);
             Assert.Equal<GamestreamStateMessageType>(GamestreamStateMessageType.Stopped, msg.State);
-            Assert.Equal<string>("14608f3c-1c4a-4f32-9da6-179ce1001e4a", msg.SessionId.ToString());
+            Assert.Equal("14608f3c-1c4a-4f32-9da6-179ce1001e4a", msg.SessionId.ToString());
         }
 
         [Fact]

--- a/Tests/SmartGlass/TestCertificate.cs
+++ b/Tests/SmartGlass/TestCertificate.cs
@@ -21,8 +21,8 @@ namespace Tests.SmartGlass
 
             Assert.NotNull(x509);
             Assert.Equal<int>(3, x509.Version);
-            Assert.Equal<string>("CN=Rust", x509.IssuerDN.ToString());
-            Assert.Equal<string>("CN=FFFFFFFFFFF", x509.SubjectDN.ToString());
+            Assert.Equal("CN=Rust", x509.IssuerDN.ToString());
+            Assert.Equal("CN=FFFFFFFFFFF", x509.SubjectDN.ToString());
             Assert.NotNull(publicKey);
         }
     }


### PR DESCRIPTION
Fix warning xUnit2006: Do not use generic Assert.Equal overload to test for string equality.