### PR TITLE
Update libraries to latest versions, Microsoft.Extensions.Logging moved to v3 with minimal changes

### DIFF
--- a/SmartGlass/Common/Logging.cs
+++ b/SmartGlass/Common/Logging.cs
@@ -10,6 +10,6 @@ namespace SmartGlass.Common
     public class Logging
     {
         public static ILoggerFactory Factory { get; private set; } =
-            new LoggerFactory().AddDebug(LogLevel.Trace);
+            LoggerFactory.Create(builder => builder.AddDebug().SetMinimumLevel(LogLevel.Trace));
     }
 }

--- a/SmartGlass/SmartGlass.csproj
+++ b/SmartGlass/SmartGlass.csproj
@@ -12,10 +12,10 @@
     <License>MIT</License>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
-    <PackageReference Include="Portable.BouncyCastle" Version="1.8.5" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.7" />
+    <PackageReference Include="Portable.BouncyCastle" Version="1.8.6.7" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">


### PR DESCRIPTION
closes #83 done so latest OpenXBox.XboxWebApi also being installed does not cause a failure due to requiring v3 of logging.

Minimal code changes for logging required but v3 of logger has a different ctor causing the issue otherwise.