### PR TITLE
Library upgrades and netstandard20 downgrade

### DIFF
--- a/SmartGlass.Cli/AuthenticateCommand.cs
+++ b/SmartGlass.Cli/AuthenticateCommand.cs
@@ -1,11 +1,7 @@
 using System;
-using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using NClap.Metadata;
-using NClap.Repl;
-
-using XboxWebApi;
 using XboxWebApi.Authentication;
 using XboxWebApi.Authentication.Model;
 
@@ -34,12 +30,8 @@ namespace SmartGlass.Cli
 
                 AuthenticationService authService = new AuthenticationService(response);
 
-                authService.Authenticate();
-
-                using (FileStream fs = File.Open(TokenFilePath, FileMode.Create))
-                {
-                    authService.DumpToFile(fs);
-                }
+                await authService.AuthenticateAsync();
+                await authService.DumpToJsonFileAsync(TokenFilePath);
             }
             catch (Exception e)
             {

--- a/SmartGlass.Cli/BroadcastCommand.cs
+++ b/SmartGlass.Cli/BroadcastCommand.cs
@@ -30,14 +30,11 @@ namespace SmartGlass.Cli
             {
                 using (FileStream fs = File.Open(TokenFilePath, FileMode.Open))
                 {
-                    AuthService = AuthenticationService.LoadFromFile(fs);
-                    AuthService.Authenticate();
+                    AuthService = await AuthenticationService.LoadFromJsonFileStream(fs);
+                    await AuthService.AuthenticateAsync();
                 }
 
-                using (FileStream fs = File.Open(TokenFilePath, FileMode.Create))
-                {
-                    AuthService.DumpToFile(fs);
-                }
+                await AuthService.DumpToJsonFileAsync(TokenFilePath);
             }
 
             Console.WriteLine($"Connecting to {Hostname}...");

--- a/SmartGlass.Cli/ConnectCommand.cs
+++ b/SmartGlass.Cli/ConnectCommand.cs
@@ -27,14 +27,11 @@ namespace SmartGlass.Cli
             {
                 using (FileStream fs = File.Open(TokenFilePath, FileMode.Open))
                 {
-                    AuthService = AuthenticationService.LoadFromFile(fs);
-                    AuthService.Authenticate();
+                    AuthService = await AuthenticationService.LoadFromJsonFileStream(fs);
+                    await AuthService.AuthenticateAsync();
                 }
 
-                using (FileStream fs = File.Open(TokenFilePath, FileMode.Create))
-                {
-                    AuthService.DumpToFile(fs);
-                }
+                await AuthService.DumpToJsonFileAsync(TokenFilePath);
             }
 
             Console.WriteLine($"Connecting to {Hostname}...");

--- a/SmartGlass.Cli/SmartGlass.Cli.csproj
+++ b/SmartGlass.Cli/SmartGlass.Cli.csproj
@@ -7,8 +7,8 @@
     <ProjectReference Include="..\SmartGlass\SmartGlass.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="NClap" Version="2.3.6" />
-    <PackageReference Include="Tx.Network" Version="2.1.1" />
-    <PackageReference Include="OpenXbox.XboxWebApi" Version="0.2.4" />
+    <PackageReference Include="NClap" Version="3.0.0" />
+    <PackageReference Include="Tx.Network" Version="3.0.3" />
+    <PackageReference Include="OpenXbox.XboxWebApi" Version="0.3.0" />
   </ItemGroup>
 </Project>

--- a/SmartGlass.Tests/SmartGlass.Tests.csproj
+++ b/SmartGlass.Tests/SmartGlass.Tests.csproj
@@ -8,8 +8,11 @@
 
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SmartGlass/SmartGlass.csproj
+++ b/SmartGlass/SmartGlass.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>OpenXbox.SmartGlass</PackageId>
     <Authors>Joel Day, Team OpenXbox</Authors>
     <Description>Xbox One SmartGlass/Arcadia client library for .NET</Description>


### PR DESCRIPTION
I have upgraded libraries for the CLI and test project and changed code where it was necessary due to API changes.

Furthermore I have downgraded smartglass' target framework to netstandard20 again, because there is obviously no need for netstandard21 but this prevents any usage of the library in the Universal Windows Platform (UWP).