### PR TITLE
Delta parameter of SystemTextInputMessage can be missing, handle this

### DIFF
--- a/SmartGlass/Messaging/Session/Messages/SystemTextInputMessage.cs
+++ b/SmartGlass/Messaging/Session/Messages/SystemTextInputMessage.cs
@@ -33,7 +33,8 @@ namespace SmartGlass.Messaging.Session.Messages
             Flags = reader.ReadUInt16BE();
             TextChunkByteStart = reader.ReadUInt32BE();
             TextChunk = reader.ReadUInt16BEPrefixedString();
-            Delta = reader.ReadUInt16BEPrefixedArray<TextDelta>();
+            if (reader.Length < reader.Position)//field is optional
+                Delta = reader.ReadUInt16BEPrefixedArray<TextDelta>();
         }
 
         public override void Serialize(EndianWriter writer)
@@ -47,7 +48,8 @@ namespace SmartGlass.Messaging.Session.Messages
             writer.WriteBE(Flags);
             writer.WriteBE(TextChunkByteStart);
             writer.WriteUInt16BEPrefixed(TextChunk);
-            // writer.Write(Delta);
+            //if (Delta != null)
+                //writer.WriteUInt32BEPrefixedArray(Delta); //no be?
         }
     }
 }


### PR DESCRIPTION
closes #91 
We tried to always read this value however on an empty textbox shown this is not sent and an exception happens.  There may be a more official way to test to see if present, but a simple length check seemed easiest.   Will be working to add full text support soon.