### PR TITLE
Avoid silently failing on exception during heartbeat loop (and improve ack log message)

### DIFF
--- a/SmartGlass/Messaging/Session/SessionMessageTransport.cs
+++ b/SmartGlass/Messaging/Session/SessionMessageTransport.cs
@@ -83,7 +83,14 @@ namespace SmartGlass.Messaging.Session
                 _lastReceived = DateTime.Now;
                 while (!_cancellationTokenSource.IsCancellationRequested)
                 {
-                    await SendMessageAckAsync(requestAck: true);
+                    try
+                    {
+                        await SendMessageAckAsync(requestAck: true);
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.LogError("Error sending heartbeat", ex);
+                    }
                     await Task.Delay(_heartbeatInterval);
                     if (DateTime.Now - _lastReceived > _heartbeatTimeout)
                     {
@@ -164,16 +171,23 @@ namespace SmartGlass.Messaging.Session
         private Task SendMessageAckAsync(uint[] processed = null, uint[] rejected = null,
                                                                   bool requestAck = false)
         {
+            var msg = $"";
             if (processed != null)
             {
-                logger.LogTrace($"Acking #{String.Join(",", processed)}");
+                msg += $"Acking server msg #{String.Join(",", processed)}";
+            }
+            else 
+            {
+                msg = "Heatbeat Ack request";
             }
 
             var ackMessage = new AckMessage();
             ackMessage.Header.RequestAcknowledge = requestAck;
             ackMessage.LowWatermark = _serverSequenceNumber;
+            msg += $" server seq number: {_serverSequenceNumber}";
             ackMessage.ProcessedList = new HashSet<uint>(processed ?? new uint[0]);
             ackMessage.RejectedList = new HashSet<uint>(rejected ?? new uint[0]);
+            logger.LogTrace(msg);
             return SendAsync(ackMessage);
         }
 


### PR DESCRIPTION
#90 exposed the protocoltimeout exception so clients could respond.

I am not sure the underlying event code would actually ever fire.   At a minimum if an exception happened during sending (ie socket closed) it would just silently kill the heartbeat loop without triggering the timeout event.

I think even in the 'best' case of the xbox just being slow to respond, it would still trigger an exception as the send function waits for the response from the server but only for the timeout window before throwing an exception.

This code doesn't actually trigger on exception, but just logs the exception lets the heartbeat loop keep running (then it will trigger the event as normal).

It also adds more details to the ack messages that get sent (to make it clear one is client heartbeat request vs acking the server's request).