### PR TITLE
Allow users to override default logging configuration

### DIFF
--- a/SmartGlass/Common/Logging.cs
+++ b/SmartGlass/Common/Logging.cs
@@ -9,7 +9,7 @@ namespace SmartGlass.Common
     /// </summary>
     public class Logging
     {
-        public static ILoggerFactory Factory { get; private set; } =
-            LoggerFactory.Create(builder => builder.AddDebug().SetMinimumLevel(LogLevel.Trace));
+        public static ILoggerFactory Factory { get; set; } =
+            LoggerFactory.Create(builder => builder.AddDebug().SetMinimumLevel(LogLevel.Trace));//note even if overwritten this will be called and thrown away
     }
 }


### PR DESCRIPTION
Allow users control over the default logging setup.   This works but not sure if it is close to creating a race condition (given the logging factory is also statically created).   If two classes were to tap the event handler and one logged something it might cause the other one to not fire in time.  No worse that currently, but potentially unexpected behavior.