### PR TITLE
Added media state tracking and event to the media channel

### DIFF
--- a/SmartGlass/Channels/MediaChannel.cs
+++ b/SmartGlass/Channels/MediaChannel.cs
@@ -20,8 +20,29 @@ namespace SmartGlass.Channels
         internal MediaChannel(ChannelMessageTransport transport)
         {
             _transport = transport;
+            _transport.MessageReceived += OnMessageReceived;
         }
 
+        private void OnMessageReceived(object sender, Common.MessageReceivedEventArgs<Messaging.Session.SessionMessageBase> e)
+        {
+            switch (e.Message)
+            {
+                case MediaStateMessage msg_state:
+                    //System.Diagnostics.Debug.WriteLine($"Got a media state message: {Newtonsoft.Json.JsonConvert.SerializeObject(msg_state)}");
+                    CurrentMediaState = msg_state.State;
+                    MediaStateChanged?.Invoke(this, new MediaStateChangedEventArgs(msg_state.State));
+                    break;
+                case MediaControllerRemovedMessage msg_removed:
+                    CurrentMediaState = null;
+                    MediaStateChanged?.Invoke(this, new MediaStateChangedEventArgs(null));
+                    break;
+            }
+
+
+
+        }
+        public event EventHandler<MediaStateChangedEventArgs> MediaStateChanged;
+        public MediaState CurrentMediaState { get; private set; }
         /// <summary>
         /// Sends a media command message.
         /// </summary>

--- a/SmartGlass/MediaState.cs
+++ b/SmartGlass/MediaState.cs
@@ -7,6 +7,11 @@ namespace SmartGlass
 
     public class MediaState
     {
+        public MediaState()
+        {
+            AsOf = DateTime.Now;
+        }
+        public DateTime AsOf { get; internal set; }
         public uint TitleId { get; internal set; }
         public string AumId { get; internal set; }
         public string AssetId { get; internal set; }

--- a/SmartGlass/MediaStateChangedEventArgs.cs
+++ b/SmartGlass/MediaStateChangedEventArgs.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace SmartGlass
+{
+    public class MediaStateChangedEventArgs : EventArgs
+    {
+        public MediaState State { get; private set;  }
+
+        public MediaStateChangedEventArgs(MediaState state)
+        {
+            State = state;
+        }
+    }
+}


### PR DESCRIPTION
Added media state tracking.  Given it is semi-broken in xbox build 19041 can't do a lot of testing.  Most of the work was already done though so likely fully OK.  Debated about the debug trace line as I figured with playing media these may fire semi often.  Add back in if it belongs (may want one for the controller removed as well.

Used the newer style type switching rather than if/elsing as I figured a bit more clean but can revert if desired.