### PR TITLE
Fixed null-reference in case of time-out.

### DIFF
--- a/SmartGlass/SmartGlassClient.cs
+++ b/SmartGlass/SmartGlassClient.cs
@@ -233,7 +233,10 @@ namespace SmartGlass
                     timedOut ? "Timeout" : "Rejection",
                     serviceType);
 
-                throw new SmartGlassException(errorMsg, response.Result);
+                if (!timedOut)
+                    throw new SmartGlassException(errorMsg, response.Result);
+                else
+                    throw new SmartGlassException(errorMsg);
             }
 
             return new ChannelMessageTransport(response.ChannelId, _sessionMessageTransport);


### PR DESCRIPTION
In case of a time-out there is no response-object, which will end up in a null-reference exception.